### PR TITLE
Add test to verify timeout interceptor

### DIFF
--- a/__tests__/interceptor/timeout.ts
+++ b/__tests__/interceptor/timeout.ts
@@ -9,13 +9,16 @@ window.fetch = jest.fn().mockImplementation(() => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve({
-        ok: true
+        ok: true,
+        json() {
+          return Promise.resolve({data: 'here'})
+        }
       })
-    }, 5000)
+    }, 1000)
   })
 })
 
-const interceptor = new Interceptor({
+const timeoutInterceptor = new Interceptor({
   timeout1: {
     timeout(url) {
       return Promise.reject('error')
@@ -33,18 +36,45 @@ const interceptor = new Interceptor({
     }
   }
 })
-
-const fetchClient = new FetchClient()
-
-fetchClient.setInterceptors(interceptor)
-fetchClient.setTimeout(1000)
+function timeout(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
 
 describe('request timeout test', () => {
   test('timeout normal', async () => {
+    const fetchClient = new FetchClient()
+
+    fetchClient.setInterceptors(timeoutInterceptor)
+    fetchClient.setTimeout(500)
     try {
       await fetchClient.get(mockUrl)
     } catch (error) {
       expect(error).toEqual('error')
+    }
+  })
+  test('clear timeout', async () => {
+    const fetchClient = new FetchClient()
+    const spy = jest.fn()
+
+    fetchClient.setTimeout(1500)
+    fetchClient.setInterceptors(new Interceptor({
+      timeout: {
+        id: 1,
+        timeout: spy.mockImplementation((url) => Promise.reject('timeout'))
+      },
+      success: {
+        id: 2,
+        success: spy.mockImplementation((data) => Promise.resolve(data))
+      }
+    }))
+
+    try {
+      await fetchClient.get(mockUrl)
+      await timeout(1000)  // ensure elapsed more time than fetchClient timeout config
+      expect(spy.mock.calls.length).toBe(1)
+      expect(spy.mock.calls[0][0].data).toBeTruthy()
+    } catch (error) {
+      expect(error).toBeFalsy()
     }
   })
 })


### PR DESCRIPTION
We need to ensure even elapsed more time than fetchClient timeout config, timeout interceptor will not be run.
So that a another test for timeout has been written to verify this feature.