### PR TITLE
Not add undefined param and enable to use list value

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ export function addQueryString(url: string, param: { [key: string]: any }): stri
   for (const key in param) {
     if (param.hasOwnProperty(key) && !isEmpty(param[key])) {
       url += url.indexOf('?') === -1 ? '?' : '&'
-      url += `${encodeURIComponent(key)}=${encodeURIComponent(param[key]).replace(/%2C/g, ',')}`
+      url += `${encodeURIComponent(key)}=${encodeURIComponent(param[key])}`
     }
   }
   return url

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 export function addQueryString(url: string, param: { [key: string]: any }): string {
   for (const key in param) {
-    if (param.hasOwnProperty(key) && param[key] != null) {
+    if (param.hasOwnProperty(key) && param[key] !== null && typeof param[key] !== 'undefined') {
       url += url.indexOf('?') === -1 ? '?' : '&'
-      url += `${encodeURIComponent(key)}=${encodeURIComponent(param[key])}`
+      url += `${encodeURIComponent(key)}=${encodeURIComponent(param[key]).replace(/%2C/g, ',')}`
     }
   }
   return url

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,15 @@
 export function addQueryString(url: string, param: { [key: string]: any }): string {
   for (const key in param) {
-    if (param.hasOwnProperty(key) && param[key] !== null && typeof param[key] !== 'undefined') {
+    if (param.hasOwnProperty(key) && !isEmpty(param[key])) {
       url += url.indexOf('?') === -1 ? '?' : '&'
       url += `${encodeURIComponent(key)}=${encodeURIComponent(param[key]).replace(/%2C/g, ',')}`
     }
   }
   return url
+}
+
+export function isEmpty(value) {
+  return typeof value === 'undefined' || value === null
 }
 
 export async function dealInterceptors(interceptors, ...data): Promise<any> {


### PR DESCRIPTION
This PR mainly aiming at two points:

* when we set an undefined value in query object, `addQueryString` utils will add this undefined value in params
* when using a list as a param value, comma will be encoded as `%2C`